### PR TITLE
binding unnecessary

### DIFF
--- a/octoprint_procastinator/static/js/procastinator.js
+++ b/octoprint_procastinator/static/js/procastinator.js
@@ -147,6 +147,6 @@ $(function() {
     OCTOPRINT_VIEWMODELS.push({
         construct: ProcastinatorViewModel,
         dependencies: ["settingsViewModel"],
-        elements: ["#settings_dialog"]
+        elements: []
     });
 });


### PR DESCRIPTION
Since you're using `get_template_configs` with `custom_bindings=False` there is no reason to bind to the settings dialog, as that binding already exists. In the current implementation it errors out on load of the page in the browser.