### PR TITLE
fix name misspelling for what's visible in the UI

### DIFF
--- a/octoprint_procastinator/__init__.py
+++ b/octoprint_procastinator/__init__.py
@@ -40,12 +40,10 @@ class ProcastinatorPlugin(octoprint.plugin.AssetPlugin,
 		    procastinator=dict(
 		        displayName=__plugin_name__,
 		        displayVersion=self._plugin_version,
-
 		        type="github_release",
 			user="juergenpabel",
 			repo="OctoPrint-Procastinator",
 			current=self._plugin_version,
-
 			pip="https://github.com/juergenpabel/OctoPrint-Procastinator/archive/{target_version}.zip"
 		    )
 		)
@@ -129,12 +127,12 @@ class ProcastinatorPlugin(octoprint.plugin.AssetPlugin,
 
 	#~ TemplatePlugin
 	def get_template_configs(self):
-		return [dict(type="settings", name="Procastinator", custom_bindings=False)]
+		return [dict(type="settings", name="Procrastinator", custom_bindings=False)]
 
 
 
-__plugin_name__ = "Procastinator"
-__plugin_description__ = "Allows your printer to procastinate on print jobs"
+__plugin_name__ = "Procrastinator"
+__plugin_description__ = "Allows your printer to procrastinate on print jobs"
 __plugin_author__ = "Jürgen Pabel"
 __plugin_license__ = "AGPLv3"
 __plugin_pythoncompat__ = ">=2.7,<4"

--- a/octoprint_procastinator/templates/procastinator_settings.jinja2
+++ b/octoprint_procastinator/templates/procastinator_settings.jinja2
@@ -1,4 +1,4 @@
-<h3>{{ _('Procastinator Settings') }}</h3>
+<h3>{{ _('Procrastinator Settings') }}</h3>
 
 <form class="form-horizontal">
     <div class="control-group">
@@ -9,7 +9,7 @@
         </div>
     </div>
     <div class="control-group">
-        <label class="control-label">{{ _('Procastination window') }}</label>
+        <label class="control-label">{{ _('Procrastination window') }}</label>
         <div class="controls">
             <input type="time" class="input-block-level" data-bind="value: settings.plugins.procastinator.starttime">
             <div class="help-block">{{ _('Starting time of time window during which print jobs may be delayed') }}</div>


### PR DESCRIPTION
@juergenpabel I've recently gone through the process of renaming a plugin and maintaining the software update check, etc. These are the only changes necessary to fix the typo for everywhere it's displayed within the OctoPrint UI. No drastic side effects that I've seen during my testing, resolves #1.