### PR TITLE
clientjs does not exist in get_assets

### DIFF
--- a/octoprint_procastinator/__init__.py
+++ b/octoprint_procastinator/__init__.py
@@ -31,8 +31,7 @@ class ProcastinatorPlugin(octoprint.plugin.AssetPlugin,
 
 
 	def get_assets(self):
-		return dict(js=["js/procastinator.js"],
-		            clientjs=["clientjs/procastinator.js"])
+		return dict(js=["js/procastinator.js", "clientjs/procastinator.js"])
 
 
 	def get_update_information(self):


### PR DESCRIPTION
I don't exactly know when the change occured but `get_assets` don't use `clientjs` anymore, so the loaded configuration for the clientjs side was never loaded and thus generating an error when trying to talk to the procastinator api.

By settings the js assets correctly the plugins don't crash at startup.

OctoPrint Version 1.5.2
OctoPi Version 0.14.0